### PR TITLE
Enforce HTTPS for milestone files to fix issue #4

### DIFF
--- a/trains.js
+++ b/trains.js
@@ -1,5 +1,5 @@
 /*global gapi,XDomainRequest */
-var URL = ["//hg.mozilla.org/", "/raw-file/tip/config/milestone.txt"];
+var URL = ["https://hg.mozilla.org/", "/raw-file/tip/config/milestone.txt"];
 var BRANCHES = [
   ["release", "releases/mozilla-release"],
   ["beta", "releases/mozilla-beta"],


### PR DESCRIPTION
This seems to fix issue #4 (see also comment on the issue).
But it would enforce the use of HTTPS for all users to get the milestones, I don't know if this is something you want.
